### PR TITLE
Allow the use of font awesome with configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ clicked:
 {{#star-rating item=song rating=song.rating on-click=(action "updateRating")  as |stars set|}}
   {{#each stars as |star|}}
     <a {{action set star.rating}}>
-      <i class="fa {{if star.full 'fa-star' 'fa-star-o'}}"></i>
+      {{if star.full}}*{{else}}_{{/if}}
     </a>
   {{/each}}
 {{/star-rating}
@@ -71,6 +71,33 @@ export default Ember.Controller.extend({
     }
   }
 });
+```
+
+## Using other icons
+
+You can use other glyphicons or font-awesome icons by specifying `fullClassNames` and `emptyClassNames` like this:
+
+```hbs
+{{star-rating item=song rating=song.rating on-click="updateRating" fullClassNames='fa fa-star' emptyClassNames='fa fa-star-o'}}
+```
+
+If you want to do this globally you can create your own component by creating a `app/components/star-rating-fa.js` file with the following content:
+
+```js
+import StarRatingComponent from 'ember-cli-star-rating/components/star-rating';
+
+export default StarRatingComponent.extend({
+
+  fullClassNames: 'fa fa-star',
+  emptyClassNames: 'fa fa-star-o'
+
+});
+```
+
+Then use it like:
+
+```hbs
+{{star-rating-fa item=song rating=song.rating on-click="updateRating"}}
 ```
 
 ## Contributing

--- a/addon/components/star-rating.js
+++ b/addon/components/star-rating.js
@@ -12,6 +12,9 @@ export default Ember.Component.extend({
   item:       null,
   "on-click": null,
 
+  fullClassNames: 'glyphicon glyphicon-star',
+  emptyClassNames: 'glyphicon glyphicon-star-empty',
+
   stars: Ember.computed('rating', 'maxRating', function() {
     var rating = Math.round(this.get('rating'));
     var fullStars = this.starRange(1, rating, 'full');

--- a/addon/templates/components/star-rating.hbs
+++ b/addon/templates/components/star-rating.hbs
@@ -2,7 +2,7 @@
   {{yield stars (action "set")}}
 {{else}}
   {{#each stars as |star|}}
-    <span class="star-rating glyphicon {{if star.full 'glyphicon-star' 'glyphicon-star-empty'}}"
+    <span class="star-rating {{if star.full fullClassNames emptyClassNames}}"
       {{action "set" star.rating}}>
     </span>
   {{/each}}

--- a/tests/integration/components/star-rating-test.js
+++ b/tests/integration/components/star-rating-test.js
@@ -28,6 +28,19 @@ test('Renders the full and empty stars correctly with integers', function(assert
   assert.equal(this.$('.glyphicon-star-empty').length, 8, "The right amount of empty stars is rendered after changing rating");
 });
 
+test('Renders the stars correctly with font-awesome icons', function(assert) {
+  assert.expect(2);
+
+  var song = Ember.Object.create({ rating: 4 });
+  this.set('song', song);
+  this.set('maxRating', 5);
+
+  this.render(hbs`{{star-rating item=song rating=song.rating maxRating=maxRating fullClassNames='fa fa-star' emptyClassNames='fa fa-star-o'}}`);
+
+  assert.equal(this.$('.fa-star').length, 4, "The right amount of full stars is rendered");
+  assert.equal(this.$('.fa-star-o').length, 1, "The right amount of empty stars is rendered");
+});
+
 test('Renders the full and empty stars correctly with float ratings', function(assert) {
   assert.expect(6);
 


### PR DESCRIPTION
This PR implements a way to allow users of the addon to specify easily that they want to use font-awesome icons instead of glyphicons.